### PR TITLE
Add Vagrant 1.8 check to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,6 @@
 Vagrant.configure("2") do |config|
+  Vagrant.require_version ">= 1.8"
+
   config.vm.box = "pcfdev/oss"
   config.vm.box_version = "0"
 


### PR DESCRIPTION
Have Vagrant check that the minimum version of Vagrant is installed, which per the readme is 1.8. If its not, you'll see an error like so:

```
$ vagrant up
This Vagrant environment has specified that it requires the Vagrant
version to satisfy the following version requirements:

  >= 1.8

You are running Vagrant 1.7.5, which does not satisfy
these requirements. Please change your Vagrant version or update
the Vagrantfile to allow this Vagrant version. However, be warned
that if the Vagrantfile has specified another version, it probably has
good reason to do so, and changing that may cause the environment to
not function properly.
```
