### PR TITLE
Fix router's TLS validation config

### DIFF
--- a/images/manifest.yml
+++ b/images/manifest.yml
@@ -744,7 +744,7 @@ properties:
       QcGDwDdRgVzV1OqgRpJTqT1O3LlpfaNVZBNQLYSpP+H/lzsr9QqQVJN0C7wh30E0
       GFoI9tfHIi1c+6Miah8tFXM5N5aMdt/sQNyAjTqOnuETYpV2O7BbAUo=
       -----END RSA PRIVATE KEY-----
-    ssl_skip_validation: true
+    skip_ssl_validation: true
     route_services_secret: route-services-secret
     route_services_recommend_https: false
   blobstore:


### PR DESCRIPTION
Gorouter uses `skip_ssl_validation`, not `ssl_skip_validation`.
- https://github.com/cloudfoundry/gorouter/blob/5171527e7054dd3b69b74eac97426eb324974a71/config/config.go#L52
- https://github.com/cloudfoundry/gorouter/blob/5171527e7054dd3b69b74eac97426eb324974a71/config/config.go#L97

As far as I know, this bug makes a CF app not working as a route service on the pcfdev environment.
