### PR TITLE
Set $PACKER_CONFIG to ~/.packerconfig if $PACKER_CONFIG does not exist.

### DIFF
--- a/bin/setup-packer
+++ b/bin/setup-packer
@@ -23,6 +23,10 @@ chmod +x $packer_bosh
 if [[ -f $PACKER_CONFIG ]]; then
   packer_config=$(cat $PACKER_CONFIG)
   echo "Updating existing ~/.packerconfig to point to downloaded packer-bosh."
+else
+	echo "No Packer Config variable found using ~/.packerconfig"
+	PACKER_CONFIG=$HOME"/.packerconfig"
+  packer_config=$(cat $PACKER_CONFIG)
 fi
 filter='. + {"provisioners": (.provisioners + {"packer-bosh": "'$packer_bosh'"})}'
 echo ${packer_config:-'{}'} | jq "$filter" >$PACKER_CONFIG


### PR DESCRIPTION
In the case that $PACKER_CONFIG is undefined, the setup_packer script will fail when it tries to pipe the output.  This will handle the case where $PACKER_CONFIG is not defined.
