### PR TITLE
Added check if shasum or sha1sum is installed

### DIFF
--- a/bin/fetch-assets
+++ b/bin/fetch-assets
@@ -24,10 +24,21 @@ shasum_matches() {
   if [[ ! -f "$path" ]]; then
     return 1
   fi
-
-  if [[ $(shasum -a 1 "$path" | cut -d ' ' -f 1) != "$checksum" ]]; then
-    return 1
+  
+  if hash shasum 2>/dev/null; then
+    if [[ $(shasum -a 1 "$path" | cut -d ' ' -f 1) != "$checksum" ]]; then
+        return 1
+    fi
+  elif hash sha1sum 2>/dev/null; then
+    if [[ $(sha1sum "$path" | cut -d ' ' -f 1) != "$checksum" ]]; then
+        return 1
+    fi
+  else
+     >&2 echo -e "\t Could not verify hash of downloaded resource, no shasum or sha1sum installed"
+     exit 1
   fi
+
+  
 }
 
 versions_json_path=$1


### PR DESCRIPTION
This will fix a build error in CentOS where no `shasum` is available but `sha1sum` is installed.
Otherwise the script will throw `/home/pcfdev_ova/pcfdev/bin/fetch-assets: line 28: shasum: command not found`.
